### PR TITLE
Use sys._MEIPASS for pyinstaller based relative path.

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ You can [tweet me](https://twitter.com/tasdikrahman) if you can't get it to work
 
 ## License
 
-[MIT License](http://prodicus.mit-license.org) © [Tasdik Rahman](http://tasdikrahman.me)
+Built with ♥ by [Tasdik Rahman](http://tasdikrahman.me) under [MIT License](http://prodicus.mit-license.org)
 
 You can find a copy of the License at http://prodicus.mit-license.org/
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Follow the youtube video to see how I fared on ``spaceShooter``
 
 ### For `Windows`
 
-- Download the prebuilt `zip file` [from here](https://github.com/prodicus/spaceShooter/releases/download/v0.0.2/spaceShooter-v0.0.2_windows.zip) and extract the file to your preferred destination by using [7-zip](http://www.7-zip.org/download.html) or [winzip](http://www.winzip.com/prod_down.html) or any other similar program of your choice.
+- Download the prebuilt `zip file` [for Windows from here](https://github.com/prodicus/spaceShooter/releases/latest) and extract the file to your preferred destination by using [7-zip](http://www.7-zip.org/download.html) or [winzip](http://www.winzip.com/prod_down.html) or any other similar program of your choice.
 - Run the executable named `spaceShooter` inside the extracted file.
 
 ### For `MAC OS X` 
@@ -49,7 +49,7 @@ Follow the youtube video to see how I fared on ``spaceShooter``
 You have to build from source to get it up and running on `OS X`. Reason?
 I don't have an `OS X` system to build the executable! So I would love for a Pull request on that one.
 
-[Building from source will do the trick though](https://github.com/prodicus/spaceShooter#os-x)
+Building from source will do the trick though
 
 
 ```bash
@@ -75,7 +75,7 @@ $ python spaceShooter.py
 
 #### Option 1: Download the zipped executable file
 
-- Download the [latest zip file](https://github.com/prodicus/spaceShooter/releases/download/v0.0.2/spaceShooter-v0.0.2_linux.zip)
+- Download the [latest zip file for linux](https://github.com/prodicus/spaceShooter/releases/latest)
 - Unzip the file
 
 If your download was saved on the `~/Downloads` folder

--- a/README.md
+++ b/README.md
@@ -156,11 +156,11 @@ For details, please refer [the Contributing page](https://github.com/prodicus/sp
 ### To-do
 
 - [x] Add the `windows` executable file
-- [ ] Add `OS X` executable file as the `Debian` based one fails to execute on it
 - [x] Add main menu for the game
 - [x] Fix [bug](https://github.com/prodicus/spaceShooter/blob/master/spaceShooter.py#L372) which stops the background music from looping 
-- [ ] Add support for `WAV` game music file as `ogg` format is not playable as described in [#1](https://github.com/prodicus/spaceShooter/issues/1)
+- [x] Add support for `WAV` game music file as `ogg` format is not playable as described in [#1](https://github.com/prodicus/spaceShooter/issues/1)
 - [ ] add feature to replay the game after all players die
+- [ ] Add `OS X` executable file as the `Debian` based one fails to execute on it
 
 
 ## Issues
@@ -170,10 +170,6 @@ You can report the bugs at the [issue tracker](https://github.com/prodicus/space
 **OR**
 
 You can [tweet me](https://twitter.com/tasdikrahman) if you can't get it to work. In fact, you should tweet me anyway.
-
-#### Known issues
-
-- The game music doesn't play on `OS X` as described in [#1](https://github.com/prodicus/spaceShooter/issues/1)
 
 ## Similar
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,26 @@
 
 The classic retro game recreated using `Pygame` and `python`.
 
+## Index
+
+- [Demo](https://github.com/prodicus/spaceShooter#demo)
+  - [Screenshots](https://github.com/prodicus/spaceShooter#screenshots)
+- [Game Features](https://github.com/prodicus/spaceShooter#game-features)
+  - [Controls](https://github.com/prodicus/spaceShooter#controls)
+- [Installation](https://github.com/prodicus/spaceShooter#installation)
+  - [For Windows](https://github.com/prodicus/spaceShooter#for-windows)
+  - [For MAC OS X](https://github.com/prodicus/spaceShooter#for-mac-os-x)
+  - [Linux/Debian based systems](https://github.com/prodicus/spaceShooter#linuxdebian-based-systems)
+    - [Option 1: Download the zipped executable file](https://github.com/prodicus/spaceShooter#option-1-download-the-zipped-executable-file)
+    - [Option 2: Build from source](https://github.com/prodicus/spaceShooter#option-2-build-from-source)
+- [Contributing](https://github.com/prodicus/spaceShooter#contributing)
+  - [Contributers](https://github.com/prodicus/spaceShooter#contributers)
+  - [To-do](https://github.com/prodicus/spaceShooter#to-do)
+- [Issues](https://github.com/prodicus/spaceShooter#issues)
+  - [Known issues](https://github.com/prodicus/spaceShooter#known-issues)
+- [Similar](https://github.com/prodicus/spaceShooter#similar)
+- [License](https://github.com/prodicus/spaceShooter#license)
+
 ## Demo
 
 Follow the youtube video to see how I fared on ``spaceShooter``
@@ -123,15 +143,17 @@ $ python spaceShooter.py
 
 Enjoy the game!
 
-## Known issues
+## Contributing
 
-- The game music doesn't play on `OS X` as described in [#1](https://github.com/prodicus/spaceShooter/issues/1)
+This game was written in one day, so the coding standards might not be up the mark. Don't be shy to make a Pull request :)
 
-## Contributers:
+For details, please refer [the Contributing page](https://github.com/prodicus/spaceShooter/blob/master/CONTRIBUTING.rst)
+
+### Contributers
 
 - [@bardlean86](https://github.com/bardlean86/) for adding the third missile powerup and the main menu
 
-## To-do:
+### To-do
 
 - [x] Add the `windows` executable file
 - [ ] Add `OS X` executable file as the `Debian` based one fails to execute on it
@@ -140,11 +162,6 @@ Enjoy the game!
 - [ ] Add support for `WAV` game music file as `ogg` format is not playable as described in [#1](https://github.com/prodicus/spaceShooter/issues/1)
 - [ ] add feature to replay the game after all players die
 
-## Contributing
-
-This game was written in one day, so the coding standards might not be up the mark. Don't be shy to make a Pull request :)
-
-For details, please refer [the Contributing page](https://github.com/prodicus/spaceShooter/blob/master/CONTRIBUTING.rst)
 
 ## Issues
 
@@ -153,6 +170,10 @@ You can report the bugs at the [issue tracker](https://github.com/prodicus/space
 **OR**
 
 You can [tweet me](https://twitter.com/tasdikrahman) if you can't get it to work. In fact, you should tweet me anyway.
+
+#### Known issues
+
+- The game music doesn't play on `OS X` as described in [#1](https://github.com/prodicus/spaceShooter/issues/1)
 
 ## Similar
 

--- a/spaceShooter.py
+++ b/spaceShooter.py
@@ -6,7 +6,7 @@
 # @Email:  prodicus@outlook.com  Github: @prodicus
 # @Last Modified by:   tasdik
 # @Last Modified by:   Branden
-# @Last Modified time: 2016-01-21
+# @Last Modified time: 2016-01-26
 # MIT License. You can find a copy of the License @ http://prodicus.mit-license.org
 
 ## Game music Attribution
@@ -29,6 +29,8 @@ WIDTH = 480
 HEIGHT = 600
 FPS = 60
 POWERUP_TIME = 5000
+BAR_LENGTH = 100
+BAR_HEIGHT = 10
 
 # Define Colors 
 WHITE = (255, 255, 255)
@@ -79,7 +81,7 @@ def main_menu():
     #pygame.mixer.music.stop()
     ready = pygame.mixer.Sound(path.join(sound_folder,'getready.ogg'))
     ready.play()
-    screen.fill((0,0,0))
+    screen.fill(BLACK)
     draw_text(screen, "GET READY!", 40, WIDTH/2, HEIGHT/2)
     pygame.display.update()
     
@@ -94,10 +96,12 @@ def draw_text(surf, text, size, x, y):
 
 
 def draw_shield_bar(surf, x, y, pct):
-    if pct < 0:
-        pct = 0 
-    BAR_LENGTH = 100
-    BAR_HEIGHT = 10
+    # if pct < 0:
+    #     pct = 0
+    pct = max(pct, 0) 
+    ## moving them to top
+    # BAR_LENGTH = 100
+    # BAR_HEIGHT = 10
     fill = (pct / 100) * BAR_LENGTH
     outline_rect = pygame.Rect(x, y, BAR_LENGTH, BAR_HEIGHT)
     fill_rect = pygame.Rect(x, y, fill, BAR_HEIGHT)

--- a/spaceShooter.py
+++ b/spaceShooter.py
@@ -15,13 +15,25 @@
 ## Additional assets by: Branden M. Ardelean (Github: @bardlean86)
 
 from __future__ import division
-import pygame
+
 import random
+import os
+import sys
+
 from os import path
 
+import pygame
+
+## PyInstaller provision to bundle resources into a single file. Needed for Mac.
+
+def resource_path(relative):
+    if hasattr(sys, "_MEIPASS"):
+        return os.path.join(sys._MEIPASS, relative)
+    return os.path.join(relative)
+
 ## assets folder
-img_dir = path.join(path.dirname(__file__), 'assets')
-sound_folder = path.join(path.dirname(__file__), 'sounds')
+img_dir = resource_path(path.join(path.dirname(__file__), 'assets'))
+sound_folder = resource_path(path.join(path.dirname(__file__), 'sounds'))
 
 ###############################
 ## to be placed in "constant.py" later
@@ -72,7 +84,7 @@ def main_menu():
                 break
             elif ev.key == pygame.K_q:
                 pygame.quit()
-                quit()
+                sys.exit()
         else:
             draw_text(screen, "Press [ENTER] To Begin", 30, WIDTH/2, HEIGHT/2)
             draw_text(screen, "or [Q] To Quit", 30, WIDTH/2, (HEIGHT/2)+40)


### PR DESCRIPTION
If the PyInstaller based mac exes are reported to work (https://github.com/prodicus/spaceShooter/issues/2) then consider including this change.

Ref: http://stackoverflow.com/questions/7674790/bundling-data-files-with-pyinstaller-onefile
